### PR TITLE
Capitalize plugin name

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,4 +1,4 @@
-name: googlemaps
+name: Googlemaps
 version: 0.3.0
 description: The **googlemaps** plugin provides a method to display a google map with KML overlay and markers
 icon: map-marker


### PR DESCRIPTION
So Admin will show it capitalized like the other plugins, for consistency
